### PR TITLE
Fixes

### DIFF
--- a/controllers/feedback.controller.js
+++ b/controllers/feedback.controller.js
@@ -218,6 +218,154 @@ function formatFeedbackData(feedbackItem) {
     };
 }
 
+const getTotalFeedbackCountHandler = async (req, res) => {
+    try {
+        const search = req.query.search ? String(req.query.search).trim() : '';
+        const startDate = req.query.startDate ? String(req.query.startDate).trim() : null;
+        const endDate = req.query.endDate ? String(req.query.endDate).trim() : null;
+        const rating = req.query.rating === 'like' || req.query.rating === 'dislike'
+            ? req.query.rating
+            : null;
+
+        if (search.length > 1000) {
+            return res.status(400).json({
+                success: false,
+                error: "Search term too long"
+            });
+        }
+
+        const { startTimestamp, endTimestamp } = parseDateRange(startDate, endDate);
+        if ((startDate && startTimestamp === null) || (endDate && endTimestamp === null)) {
+            return res.status(400).json({
+                success: false,
+                error: "Invalid date format. Use ISO date string (YYYY-MM-DD) or unix timestamp"
+            });
+        }
+
+        if (startTimestamp && endTimestamp && startTimestamp > endTimestamp) {
+            return res.status(400).json({
+                success: false,
+                error: "Start date cannot be after end date"
+            });
+        }
+
+        const totalCount = await getTotalFeedbackCount(search, startDate, endDate, rating);
+
+        res.status(200).json({
+            success: true,
+            data: {
+                totalCount
+            },
+            filters: {
+                search,
+                rating,
+                startDate,
+                endDate,
+                appliedStartTimestamp: startTimestamp,
+                appliedEndTimestamp: endTimestamp
+            }
+        });
+    } catch (error) {
+        console.error("Error fetching total feedback count:", error);
+        res.status(500).json({
+            success: false,
+            error: "Error fetching total feedback count"
+        });
+    }
+};
+
+const fetchAllFeedbackFromDBHandler = async (req, res) => {
+    try {
+        const page = Math.max(1, parseInt(req.query.page) || 1);
+        const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 10));
+        const search = req.query.search ? String(req.query.search).trim() : '';
+        const startDate = req.query.startDate ? String(req.query.startDate).trim() : null;
+        const endDate = req.query.endDate ? String(req.query.endDate).trim() : null;
+        const rating = req.query.rating === 'like' || req.query.rating === 'dislike'
+            ? req.query.rating
+            : null;
+        const sortBy = req.query.sortBy;
+        const sortOrder = req.query.sortOrder === "asc" ? "ASC" : "DESC";
+
+        if (search.length > 1000) {
+            return res.status(400).json({
+                success: false,
+                error: "Search term too long"
+            });
+        }
+
+        const { startTimestamp, endTimestamp } = parseDateRange(startDate, endDate);
+        if ((startDate && startTimestamp === null) || (endDate && endTimestamp === null)) {
+            return res.status(400).json({
+                success: false,
+                error: "Invalid date format. Use ISO date string (YYYY-MM-DD) or unix timestamp"
+            });
+        }
+
+        if (startTimestamp && endTimestamp && startTimestamp > endTimestamp) {
+            return res.status(400).json({
+                success: false,
+                error: "Start date cannot be after end date"
+            });
+        }
+
+        const data = await fetchAllFeedbackFromDB(
+            page,
+            limit,
+            search,
+            startDate,
+            endDate,
+            rating,
+            sortBy,
+            sortOrder
+        );
+
+        res.status(200).json({
+            success: true,
+            data,
+            pagination: {
+                currentPage: page,
+                itemsPerPage: limit,
+                itemsReturned: data.length
+            },
+            filters: {
+                search,
+                rating,
+                startDate,
+                endDate,
+                sortBy: sortBy || null,
+                sortOrder,
+                appliedStartTimestamp: startTimestamp,
+                appliedEndTimestamp: endTimestamp
+            }
+        });
+    } catch (error) {
+        console.error("Error fetching feedback from database:", error);
+        res.status(500).json({
+            success: false,
+            error: "Error fetching feedback from database"
+        });
+    }
+};
+
+const formatFeedbackDataHandler = async (req, res) => {
+    try {
+        res.status(200).json({
+            success: true,
+            message: "This endpoint is for internal data formatting only",
+            data: {
+                description: "Use GET /feedback to retrieve formatted feedback data"
+            }
+        });
+    } catch (error) {
+        console.error("Error in format feedback data handler:", error);
+        res.status(500).json({
+            success: false,
+            error: "Error in format feedback data handler"
+        });
+    }
+};
+
 // Controller function to get all feedback with pagination, search, and date filtering
 async function getAllFeedback(req, res) {
     try {
@@ -752,5 +900,8 @@ module.exports = {
     getTotalFeedbackCount,
     fetchAllFeedbackFromDB,
     formatFeedbackData,
-    getTotalLikesDislikesCount
+    getTotalLikesDislikesCount,
+    getTotalFeedbackCountHandler,
+    fetchAllFeedbackFromDBHandler,
+    formatFeedbackDataHandler
 };

--- a/controllers/questions.controller.js
+++ b/controllers/questions.controller.js
@@ -161,6 +161,157 @@ function formatQuestionData(row) {
   };
 }
 
+const getTotalQuestionsCountHandler = async (req, res) => {
+  try {
+    const search = req.query.search ? String(req.query.search).trim() : "";
+    const startDate = req.query.startDate
+      ? String(req.query.startDate).trim()
+      : null;
+    const endDate = req.query.endDate ? String(req.query.endDate).trim() : null;
+
+    if (search.length > 1000) {
+      return res.status(400).json({
+        success: false,
+        error: "Search term too long",
+      });
+    }
+
+    const { startTimestamp, endTimestamp } = parseDateRange(startDate, endDate);
+    if (
+      (startDate && startTimestamp === null) ||
+      (endDate && endTimestamp === null)
+    ) {
+      return res.status(400).json({
+        success: false,
+        error:
+          "Invalid date format. Use ISO date string (YYYY-MM-DD) or unix timestamp",
+      });
+    }
+
+    if (startTimestamp && endTimestamp && startTimestamp > endTimestamp) {
+      return res.status(400).json({
+        success: false,
+        error: "Start date cannot be after end date",
+      });
+    }
+
+    const totalCount = await getTotalQuestionsCount(search, startDate, endDate);
+
+    res.status(200).json({
+      success: true,
+      data: {
+        totalCount,
+      },
+      filters: {
+        search,
+        startDate,
+        endDate,
+        appliedStartTimestamp: startTimestamp,
+        appliedEndTimestamp: endTimestamp,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching total questions count:", error);
+    res.status(500).json({
+      success: false,
+      error: "Error fetching total questions count",
+    });
+  }
+};
+
+const fetchQuestionsFromDBHandler = async (req, res) => {
+  try {
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 10));
+    const search = req.query.search ? String(req.query.search).trim() : "";
+    const startDate = req.query.startDate
+      ? String(req.query.startDate).trim()
+      : null;
+    const endDate = req.query.endDate ? String(req.query.endDate).trim() : null;
+    const sortBy = req.query.sortBy;
+    const sortOrder = req.query.sortOrder === "asc" ? "ASC" : "DESC";
+
+    if (search.length > 1000) {
+      return res.status(400).json({
+        success: false,
+        error: "Search term too long",
+      });
+    }
+
+    const { startTimestamp, endTimestamp } = parseDateRange(startDate, endDate);
+    if (
+      (startDate && startTimestamp === null) ||
+      (endDate && endTimestamp === null)
+    ) {
+      return res.status(400).json({
+        success: false,
+        error:
+          "Invalid date format. Use ISO date string (YYYY-MM-DD) or unix timestamp",
+      });
+    }
+
+    if (startTimestamp && endTimestamp && startTimestamp > endTimestamp) {
+      return res.status(400).json({
+        success: false,
+        error: "Start date cannot be after end date",
+      });
+    }
+
+    const data = await fetchQuestionsFromDB(
+      page,
+      limit,
+      search,
+      startDate,
+      endDate,
+      sortBy,
+      sortOrder
+    );
+
+    res.status(200).json({
+      success: true,
+      data,
+      pagination: {
+        currentPage: page,
+        itemsPerPage: limit,
+        itemsReturned: data.length,
+      },
+      filters: {
+        search,
+        startDate,
+        endDate,
+        sortBy: sortBy || null,
+        sortOrder,
+        appliedStartTimestamp: startTimestamp,
+        appliedEndTimestamp: endTimestamp,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching questions from database:", error);
+    res.status(500).json({
+      success: false,
+      error: "Error fetching questions from database",
+    });
+  }
+};
+
+const formatQuestionDataHandler = async (req, res) => {
+  try {
+    res.status(200).json({
+      success: true,
+      message: "This endpoint is for internal data formatting only",
+      data: {
+        description: "Use GET /questions to retrieve formatted question data",
+      },
+    });
+  } catch (error) {
+    console.error("Error in format question data handler:", error);
+    res.status(500).json({
+      success: false,
+      error: "Error in format question data handler",
+    });
+  }
+};
+
 const getQuestions = async (req, res) => {
   try {
     // Extract and sanitize pagination parameters from query string
@@ -880,4 +1031,7 @@ module.exports = {
   getTotalQuestionsCount,
   fetchQuestionsFromDB,
   formatQuestionData,
+  getTotalQuestionsCountHandler,
+  fetchQuestionsFromDBHandler,
+  formatQuestionDataHandler,
 };

--- a/controllers/sessions.controller.js
+++ b/controllers/sessions.controller.js
@@ -202,6 +202,137 @@ function formatSessionData(row) {
     };
 }
 
+const getTotalSessionsCountHandler = async (req, res) => {
+    try {
+        const search = req.query.search ? String(req.query.search).trim() : '';
+        const startDate = req.query.startDate ? String(req.query.startDate).trim() : null;
+        const endDate = req.query.endDate ? String(req.query.endDate).trim() : null;
+
+        if (search.length > 1000) {
+            return res.status(400).json({
+                success: false,
+                error: "Search term too long"
+            });
+        }
+
+        const { startTimestamp, endTimestamp } = parseDateRange(startDate, endDate);
+        if ((startDate && startTimestamp === null) || (endDate && endTimestamp === null)) {
+            return res.status(400).json({
+                success: false,
+                error: "Invalid date format. Use ISO date string (YYYY-MM-DD) or unix timestamp"
+            });
+        }
+
+        if (startTimestamp && endTimestamp && startTimestamp > endTimestamp) {
+            return res.status(400).json({
+                success: false,
+                error: "Start date cannot be after end date"
+            });
+        }
+
+        const totalCount = await getTotalSessionsCount(search, startDate, endDate);
+
+        res.status(200).json({
+            success: true,
+            data: {
+                totalCount
+            },
+            filters: {
+                search,
+                startDate,
+                endDate,
+                appliedStartTimestamp: startTimestamp,
+                appliedEndTimestamp: endTimestamp
+            }
+        });
+    } catch (error) {
+        console.error("Error fetching total sessions count:", error);
+        res.status(500).json({
+            success: false,
+            error: "Error fetching total sessions count"
+        });
+    }
+};
+
+const fetchSessionsFromDBHandler = async (req, res) => {
+    try {
+        const page = Math.max(1, parseInt(req.query.page) || 1);
+        const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 10));
+        const search = req.query.search ? String(req.query.search).trim() : '';
+        const startDate = req.query.startDate ? String(req.query.startDate).trim() : null;
+        const endDate = req.query.endDate ? String(req.query.endDate).trim() : null;
+        const sortBy = req.query.sortBy;
+        const sortOrder = req.query.sortOrder === "asc" ? "ASC" : "DESC";
+
+        if (search.length > 1000) {
+            return res.status(400).json({
+                success: false,
+                error: "Search term too long"
+            });
+        }
+
+        const { startTimestamp, endTimestamp } = parseDateRange(startDate, endDate);
+        if ((startDate && startTimestamp === null) || (endDate && endTimestamp === null)) {
+            return res.status(400).json({
+                success: false,
+                error: "Invalid date format. Use ISO date string (YYYY-MM-DD) or unix timestamp"
+            });
+        }
+
+        if (startTimestamp && endTimestamp && startTimestamp > endTimestamp) {
+            return res.status(400).json({
+                success: false,
+                error: "Start date cannot be after end date"
+            });
+        }
+
+        const data = await fetchSessionsFromDB(page, limit, search, startDate, endDate, sortBy, sortOrder);
+
+        res.status(200).json({
+            success: true,
+            data,
+            pagination: {
+                currentPage: page,
+                itemsPerPage: limit,
+                itemsReturned: data.length
+            },
+            filters: {
+                search,
+                startDate,
+                endDate,
+                sortBy: sortBy || null,
+                sortOrder,
+                appliedStartTimestamp: startTimestamp,
+                appliedEndTimestamp: endTimestamp
+            }
+        });
+    } catch (error) {
+        console.error("Error fetching sessions from database:", error);
+        res.status(500).json({
+            success: false,
+            error: "Error fetching sessions from database"
+        });
+    }
+};
+
+const formatSessionDataHandler = async (req, res) => {
+    try {
+        res.status(200).json({
+            success: true,
+            message: "This endpoint is for internal data formatting only",
+            data: {
+                description: "Use GET /sessions to retrieve formatted session data"
+            }
+        });
+    } catch (error) {
+        console.error("Error in format session data handler:", error);
+        res.status(500).json({
+            success: false,
+            error: "Error in format session data handler"
+        });
+    }
+};
+
 const getSessions = async (req, res) => {
     try {
         // Extract and sanitize pagination parameters from query string
@@ -907,5 +1038,8 @@ module.exports = {
     getSessionsGraph,
     getTotalSessionsCount,
     fetchSessionsFromDB,
-    formatSessionData
+    formatSessionData,
+    getTotalSessionsCountHandler,
+    fetchSessionsFromDBHandler,
+    formatSessionDataHandler
 };

--- a/controllers/translation.controller.js
+++ b/controllers/translation.controller.js
@@ -1,0 +1,99 @@
+const {
+  getPretranslatedQueries,
+  getEnglishQueriesFromTraces,
+} = require("../langfuse/pretranslation");
+
+function parseAndValidateDateRange(startDate, endDate) {
+  const parsedStart = startDate ? new Date(startDate) : null;
+  const parsedEnd = endDate ? new Date(endDate) : null;
+
+  if (parsedStart && Number.isNaN(parsedStart.getTime())) {
+    return { valid: false, error: "Invalid startDate. Use ISO date string." };
+  }
+  if (parsedEnd && Number.isNaN(parsedEnd.getTime())) {
+    return { valid: false, error: "Invalid endDate. Use ISO date string." };
+  }
+  if (parsedStart && parsedEnd && parsedStart.getTime() > parsedEnd.getTime()) {
+    return { valid: false, error: "startDate cannot be after endDate" };
+  }
+
+  return { valid: true };
+}
+
+const getTranslationBuckets = async (req, res) => {
+  try {
+    const startDate = req.query.startDate ? String(req.query.startDate).trim() : null;
+    const endDate = req.query.endDate ? String(req.query.endDate).trim() : null;
+
+    const translatedLimit = Math.max(
+      1,
+      Math.min(1000, parseInt(req.query.translatedLimit, 10) || 100)
+    );
+    const translatedCursor = req.query.translatedCursor
+      ? String(req.query.translatedCursor)
+      : null;
+
+    const englishPage = Math.max(1, parseInt(req.query.englishPage, 10) || 1);
+    const englishLimit = Math.max(
+      1,
+      Math.min(200, parseInt(req.query.englishLimit, 10) || 100)
+    );
+
+    const validation = parseAndValidateDateRange(startDate, endDate);
+    if (!validation.valid) {
+      return res.status(400).json({
+        success: false,
+        error: validation.error,
+      });
+    }
+
+    const [translated, english] = await Promise.all([
+      getPretranslatedQueries({
+        startDate,
+        endDate,
+        cursor: translatedCursor,
+        limit: translatedLimit,
+      }),
+      getEnglishQueriesFromTraces({
+        startDate,
+        endDate,
+        page: englishPage,
+        limit: englishLimit,
+      }),
+    ]);
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        pretranslatedQueries: translated.items,
+        englishQueries: english.items,
+      },
+      pagination: {
+        pretranslated: {
+          limit: translatedLimit,
+          nextCursor: translated.nextCursor,
+        },
+        english: english.pagination,
+      },
+      summary: {
+        pretranslatedCount: translated.items.length,
+        englishCount: english.items.length,
+      },
+      filters: {
+        startDate,
+        endDate,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching translation buckets:", error);
+    return res.status(500).json({
+      success: false,
+      error: "Error fetching translation buckets",
+      details: error.message,
+    });
+  }
+};
+
+module.exports = {
+  getTranslationBuckets,
+};

--- a/controllers/translation.controller.js
+++ b/controllers/translation.controller.js
@@ -76,8 +76,9 @@ const getTranslationBuckets = async (req, res) => {
         english: english.pagination,
       },
       summary: {
-        pretranslatedCount: translated.items.length,
+        translatedCount: translated.items.length,
         englishCount: english.items.length,
+        pretranslatedCount: translated.items.length,
       },
       filters: {
         startDate,

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const sessionRoutes = require("./routes/sessionRoutes");
 const feedbackRoutes = require("./routes/feedbackRoutes");
 const errorRoutes = require("./routes/errorRoutes");
 const dashboardRoutes = require("./routes/dashboard.Routes");
+const translationRoutes = require("./routes/translationRoutes");
 const authController = require("./controllers/auth.controller");
 const leaderboardRoutes = require("./routes/leaderboard.Routes");
 const villageRoutes = require("./routes/villageRoutes");
@@ -45,6 +46,7 @@ app.use("/v1", authController, sessionRoutes);
 app.use("/v1", authController, feedbackRoutes);
 app.use("/v1", authController, errorRoutes);
 app.use("/v1", authController, dashboardRoutes);
+app.use("/v1", authController, translationRoutes);
 app.use("/v1/api/villages", authController, villageRoutes);
 
 const PORT = process.env.PORT || 3000;

--- a/langfuse/pretranslation.js
+++ b/langfuse/pretranslation.js
@@ -1,0 +1,168 @@
+const { LangfuseConfig: config } = require("./config.js");
+
+const authString = `${config.public_key || ""}:${config.secret_key || ""}`;
+const encodedAuth = Buffer.from(authString).toString("base64");
+const lfHeaders = new Headers();
+lfHeaders.append("Authorization", `Basic ${encodedAuth}`);
+
+function assertLangfuseConfig() {
+  if (!config.base_url || !config.public_key || !config.secret_key) {
+    throw new Error(
+      "Langfuse is not configured. Set LANGFUSE_BASE_URL, LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY"
+    );
+  }
+}
+
+async function fetchLangfuseJson(url) {
+  const response = await fetch(url, {
+    method: "GET",
+    headers: lfHeaders,
+    redirect: "follow",
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(
+      `Langfuse API request failed (${response.status}): ${payload?.message || "unknown error"}`
+    );
+  }
+  return payload;
+}
+
+function normalizeIso(dateValue) {
+  if (!dateValue) return null;
+  const parsed = new Date(dateValue);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+function sanitizeLimit(rawLimit, defaultValue = 100) {
+  const parsed = parseInt(rawLimit, 10);
+  if (Number.isNaN(parsed)) return defaultValue;
+  return Math.max(1, Math.min(1000, parsed));
+}
+
+async function getPretranslatedQueries({
+  startDate = null,
+  endDate = null,
+  cursor = null,
+  limit = 100,
+}) {
+  assertLangfuseConfig();
+  const requestLimit = sanitizeLimit(limit, 100);
+  const startIso = normalizeIso(startDate);
+  const endIso = normalizeIso(endDate);
+
+  const url = new URL(`${config.base_url.trim().replace(/\/$/, "")}/api/public/v2/observations`);
+  url.searchParams.append("name", "query_pretranslation");
+  url.searchParams.append("type", "GENERATION");
+  url.searchParams.append("limit", String(requestLimit));
+  if (cursor) url.searchParams.append("cursor", String(cursor));
+  if (startIso) url.searchParams.append("fromStartTime", startIso);
+  if (endIso) url.searchParams.append("toStartTime", endIso);
+
+  const payload = await fetchLangfuseJson(url);
+  const rows = Array.isArray(payload?.data) ? payload.data : [];
+
+  const items = rows.map((row) => {
+    const input = row?.input && typeof row.input === "object" ? row.input : {};
+    return {
+      observationId: row?.id || null,
+      traceId: row?.traceId || null,
+      sessionId: row?.sessionId || null,
+      userId: row?.userId || null,
+      sourceLang: input?.source_lang || null,
+      targetLang: input?.target_lang || null,
+      originalQuery: input?.text || null,
+      translatedQuery:
+        typeof row?.output === "string"
+          ? row.output
+          : row?.output?.text || row?.output?.translated_text || null,
+      startTime: row?.startTime || null,
+      endTime: row?.endTime || null,
+      model: row?.providedModelName || row?.model || null,
+      provider: row?.metadata?.translation_provider || null,
+    };
+  });
+
+  return {
+    items,
+    nextCursor: payload?.meta?.nextCursor || payload?.meta?.cursor || null,
+  };
+}
+
+async function getEnglishQueriesFromTraces({
+  startDate = null,
+  endDate = null,
+  page = 1,
+  limit = 100,
+}) {
+  assertLangfuseConfig();
+  const safePage = Math.max(1, parseInt(page, 10) || 1);
+  const requestLimit = Math.max(1, Math.min(200, parseInt(limit, 10) || 100));
+  const startIso = normalizeIso(startDate);
+  const endIso = normalizeIso(endDate);
+  const englishItems = [];
+  let currentTracePage = safePage;
+  let scannedTracePages = 0;
+  let hasMorePages = true;
+  let lastMeta = null;
+
+  while (englishItems.length < requestLimit && hasMorePages && scannedTracePages < 10) {
+    const url = new URL(`${config.base_url.trim().replace(/\/$/, "")}/api/public/traces`);
+    url.searchParams.append("page", String(currentTracePage));
+    url.searchParams.append("limit", String(requestLimit));
+    url.searchParams.append("orderBy", "timestamp.desc");
+    if (startIso) url.searchParams.append("fromTimestamp", startIso);
+    if (endIso) url.searchParams.append("toTimestamp", endIso);
+
+    const payload = await fetchLangfuseJson(url);
+    const rows = Array.isArray(payload?.data) ? payload.data : [];
+    lastMeta = payload?.meta || null;
+    scannedTracePages += 1;
+
+    for (const row of rows) {
+      const sourceFromMetadata = row?.metadata?.source_lang;
+      const sourceFromInput =
+        row?.input && typeof row.input === "object" ? row.input.source_lang : null;
+      const sourceLang = String(sourceFromMetadata || sourceFromInput || "")
+        .trim()
+        .toLowerCase();
+      if (sourceLang !== "en" && sourceLang !== "english") continue;
+
+      const input = row?.input && typeof row.input === "object" ? row.input : {};
+      englishItems.push({
+        traceId: row?.id || null,
+        sessionId: row?.sessionId || null,
+        userId: row?.userId || null,
+        sourceLang: (row?.metadata?.source_lang || input?.source_lang || "en").toLowerCase(),
+        targetLang: row?.metadata?.target_lang || input?.target_lang || null,
+        originalQuery: input?.query || input?.text || null,
+        timestamp: row?.timestamp || null,
+        name: row?.name || null,
+      });
+
+      if (englishItems.length >= requestLimit) break;
+    }
+
+    const totalPages = Number(lastMeta?.totalPages || 0);
+    const pageFromMeta = Number(lastMeta?.page || currentTracePage);
+    hasMorePages = totalPages > 0 ? pageFromMeta < totalPages : rows.length > 0;
+    currentTracePage += 1;
+  }
+
+  return {
+    items: englishItems,
+    pagination: {
+      page: safePage,
+      limit: requestLimit,
+      scannedTracePages,
+      nextPage: hasMorePages ? currentTracePage : null,
+      sourceMeta: lastMeta,
+    },
+  };
+}
+
+module.exports = {
+  getPretranslatedQueries,
+  getEnglishQueriesFromTraces,
+};

--- a/routes/feedbackRoutes.js
+++ b/routes/feedbackRoutes.js
@@ -18,12 +18,12 @@ router.get('/feedback/id/:id', feedbackController.getFeedbackByid);
 router.get('/feedback/session/:sessionId', feedbackController.getFeedbackBySessionId);
 
 // Route for getting total feedback count
-router.get('/feedback/count', feedbackController.getTotalFeedbackCount);
+router.get('/feedback/count', feedbackController.getTotalFeedbackCountHandler);
 
 // Route for fetching feedback from DB
-router.get('/feedback/fetch', feedbackController.fetchAllFeedbackFromDB);
+router.get('/feedback/fetch', feedbackController.fetchAllFeedbackFromDBHandler);
 
 // Route for formatting feedback data
-router.get('/feedback/format', feedbackController.formatFeedbackData);
+router.get('/feedback/format', feedbackController.formatFeedbackDataHandler);
 
 module.exports = router;    

--- a/routes/questionRoutes.js
+++ b/routes/questionRoutes.js
@@ -6,9 +6,9 @@ const {
     getQuestionsBySessionId,
     getQuestionStats,
     getQuestionsGraph,
-    getTotalQuestionsCount,
-    fetchQuestionsFromDB,
-    formatQuestionData
+    getTotalQuestionsCountHandler,
+    fetchQuestionsFromDBHandler,
+    formatQuestionDataHandler
 } = require('../controllers/questions.controller');
 
 const router = express.Router();
@@ -22,9 +22,6 @@ router.get('/questions/stats', getQuestionStats);
 // Get questions graph data for time-series visualization
 router.get('/questions/graph', getQuestionsGraph);
 
-// Get single question by ID
-router.get('/questions/:id', getQuestionById);
-
 // Get questions by user ID with pagination
 router.get('/users/:userId/questions', getQuestionsByUserId);
 
@@ -32,12 +29,15 @@ router.get('/users/:userId/questions', getQuestionsByUserId);
 router.get('/questions/session/:sessionId', getQuestionsBySessionId);
 
 // Get total questions count
-router.get('/questions/count', getTotalQuestionsCount);
+router.get('/questions/count', getTotalQuestionsCountHandler);
 
 // Fetch questions from DB
-router.get('/questions/fetch', fetchQuestionsFromDB);
+router.get('/questions/fetch', fetchQuestionsFromDBHandler);
 
 // Format question data
-router.get('/questions/format', formatQuestionData);
+router.get('/questions/format', formatQuestionDataHandler);
+
+// Get single question by ID
+router.get('/questions/:id', getQuestionById);
 
 module.exports = router;

--- a/routes/sessionRoutes.js
+++ b/routes/sessionRoutes.js
@@ -5,9 +5,9 @@ const {
     getSessionsByUserId,
     getSessionStats,
     getSessionsGraph,
-    getTotalSessionsCount,
-    fetchSessionsFromDB,
-    formatSessionData
+    getTotalSessionsCountHandler,
+    fetchSessionsFromDBHandler,
+    formatSessionDataHandler
 } = require('../controllers/sessions.controller');
 
 const router = express.Router();
@@ -21,19 +21,19 @@ router.get('/sessions/stats', getSessionStats);
 // Get sessions graph data for time-series visualization
 router.get('/sessions/graph', getSessionsGraph);
 
-// Get single session details by session ID
-router.get('/sessions/:sessionId', getSessionById);
-
 // Get sessions by user ID with pagination
 router.get('/users/:userId/sessions', getSessionsByUserId);
 
 // Get total sessions count
-router.get('/sessions/count', getTotalSessionsCount);
+router.get('/sessions/count', getTotalSessionsCountHandler);
 
 // Fetch sessions from DB
-router.get('/sessions/fetch', fetchSessionsFromDB);
+router.get('/sessions/fetch', fetchSessionsFromDBHandler);
 
 // Format session data
-router.get('/sessions/format', formatSessionData);
+router.get('/sessions/format', formatSessionDataHandler);
+
+// Get single session details by session ID
+router.get('/sessions/:sessionId', getSessionById);
 
 module.exports = router;

--- a/routes/translationRoutes.js
+++ b/routes/translationRoutes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const { getTranslationBuckets } = require("../controllers/translation.controller");
+
+const router = express.Router();
+
+// Get translated vs already-English query buckets from Langfuse
+router.get("/translations/pretranslation", getTranslationBuckets);
+
+module.exports = router;


### PR DESCRIPTION
-Fixed /count, /fetch, /format endpoints for questions,feedbacks,errors and suggestions.
-Added GET /v1/translations/pretranslation (JWT-protected, same auth as other /v1 routes).
Fetches two buckets from Langfuse in parallel:
Pre-translated queries — observations named query_pretranslation (original + translated text).
English queries — traces where source_lang is en / english.
Supports date filtering and pagination (translatedCursor, englishPage / limits).
Response includes summary.translatedCount, summary.englishCount, and summary.pretranslatedCount (alias for backward compatibility).